### PR TITLE
Rate limits for a server creation

### DIFF
--- a/servers/tests.py
+++ b/servers/tests.py
@@ -1,13 +1,13 @@
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
-from django.test import Client, TestCase
+from django.test import Client, TransactionTestCase
 
 from games.models import Game, GameVersion, Mod, ModVersion
 from servers.models import Server
 
 
-class ServerTestCase(TestCase):
+class ServerTestCase(TransactionTestCase):
     def setUp(self):
         self.game = Game.objects.create(
             name='Minecraft: Java Edition',

--- a/servers/tests.py
+++ b/servers/tests.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.contrib.auth.models import User
 from django.test import Client, TestCase
 
@@ -5,7 +7,7 @@ from games.models import Game, GameVersion, Mod, ModVersion
 from servers.models import Server
 
 
-class GameTestCase(TestCase):
+class ServerTestCase(TestCase):
     def setUp(self):
         self.game = Game.objects.create(
             name='Minecraft: Java Edition',
@@ -254,6 +256,37 @@ class GameTestCase(TestCase):
             }
         )
         self.assertEqual(response.status_code, 201)
+
+    @patch('servers.throttling.CreateServerRateThrottle.rate', '1/min')
+    def test_create_server_throttling(self):
+        c = Client()
+        c.login(username='username', password='password')
+
+        response = c.post(
+            '/api/servers/',
+            {
+                'game_id': self.game.id,
+                'version_id': self.version.id,
+                'config': {},
+            },
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 201)
+
+        throttle_response = c.post(
+            '/api/servers/',
+            {
+                'game_id': self.game.id,
+                'version_id': self.version.id,
+                'config': {},
+            },
+            content_type='application/json',
+        )
+        self.assertEqual(throttle_response.status_code, 429)
+        self.assertDictEqual(
+            throttle_response.json(),
+            {'detail': 'Request was throttled. Expected available in 60 seconds.'}
+        )
 
     def test_build_endpoint(self):
         c = Client()

--- a/servers/throttling.py
+++ b/servers/throttling.py
@@ -1,0 +1,6 @@
+from rest_framework.throttling import UserRateThrottle
+
+
+class CreateServerRateThrottle(UserRateThrottle):
+    scope = 'create_server'
+    rate = '5/min'

--- a/servers/views.py
+++ b/servers/views.py
@@ -9,11 +9,17 @@ from common.tasks import server_build_task, server_run_task, server_stop_task
 from servers.models import Server, ServerBuild
 from servers.serializers import (CreateServerSerializer, ServerSerializer,
                                  UpdateServerSerializer)
+from servers.throttling import CreateServerRateThrottle
 
 
 class ServersViewSet(viewsets.GenericViewSet, ListModelMixin, RetrieveModelMixin, UpdateModelMixin):
 
     serializer_class = ServerSerializer
+
+    def get_throttles(self):
+        if self.action == 'create':
+            return [CreateServerRateThrottle()]
+        return []
 
     def get_queryset(self):
         return Server.objects.filter(owner=self.request.user)


### PR DESCRIPTION
close #66 
@BehindLoader пока добавил ограничения (5 серверов в минуту) только для создания серверов, больше же никуда не нужно?
в качестве кэша для тротлинга используется память приложения, поэтому если сервер перезапустить, то временные ограничения сбросятся. это тоже ок я думаю